### PR TITLE
Remove Python 3.5 from CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"


### PR DESCRIPTION
# Description

Remove Python 3.5 from CI settings

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
