### PR TITLE
Expose metrics on port 9000

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,7 +42,7 @@ service:
         topic: platform.payload-status
     - name: ccx_messaging.watchers.stats_watcher.StatsWatcher
       kwargs:
-        prometheus_port: 8000
+        prometheus_port: 9000
     - name: ccx_messaging.watchers.cluster_id_watcher.ClusterIdWatcher
 
   logging:

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -95,7 +95,7 @@ objects:
           readinessProbe:
             httpGet:
               path: /metrics
-              port: 8000
+              port: 9000
               scheme: HTTP
             initialDelaySeconds: 20
             successThreshold: 1
@@ -103,7 +103,7 @@ objects:
           livenessProbe:
             httpGet:
               path: /metrics
-              port: 8000
+              port: 9000
               scheme: HTTP
             initialDelaySeconds: 20
             successThreshold: 1
@@ -112,7 +112,7 @@ objects:
           startupProbe:
             httpGet:
               path: /metrics
-              port: 8000
+              port: 9000
               scheme: HTTP
             initialDelaySeconds: 20
             successThreshold: 1
@@ -206,7 +206,7 @@ objects:
               topic: ${PAYLOAD_TRACKER_TOPIC}
           - name: ccx_messaging.watchers.stats_watcher.StatsWatcher
             kwargs:
-              prometheus_port: 8000
+              prometheus_port: 9000
 
         logging:
           version: 1
@@ -243,7 +243,7 @@ objects:
   metadata:
     annotations:
       prometheus.io/path: /metrics
-      prometheus.io/port: "8000"
+      prometheus.io/port: "9000"
       prometheus.io/scheme: http
       prometheus.io/scrape: "true"
     name: sha-extractor-prometheus-exporter
@@ -252,9 +252,9 @@ objects:
   spec:
     ports:
       - name: sha-extractor-port-metrics
-        port: 8000
+        port: 9000
         protocol: TCP
-        targetPort: 8000
+        targetPort: 9000
     selector:
       app: sha-extractor
 


### PR DESCRIPTION
# Description

In the namespace that this service is deployed in, the default exposed ports for metrics scraping is 9000, not 8000.

Fixes CCXDEV-12806

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI + stage

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
