### PR TITLE
[CCXDEV-12992] Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# CCX Processing team members are the default owners of the repository
-* @tisnik @Bee-lee @JoseLSegura @dpensi @matysek @epapbak @JiriPapousek @juandspy @jdrobena


### PR DESCRIPTION
# Description
Remove codeowners since that is no longer required.

## Type of change
- Bug fix (non-breaking change which fixes an issue)